### PR TITLE
Add mode filter panel for active spot pulses

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -210,6 +210,41 @@
     .filter-chip { padding: 9px 12px; font-size: 14px; }
 }
 
+/* ================= Mode filter panel ================= */
+.mode-filter-panel {
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.mode-filter-row {
+    display: flex;
+    gap: 8px;
+    justify-content: space-around;
+    width: 100%;
+}
+.mode-filter-row button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}
+.mode-filter-row button:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+.mode-filter-labels {
+    display: flex;
+    justify-content: space-around;
+    width: 100%;
+    font-size: 0.8em;
+    margin-top: 4px;
+}
+.mode-filter-btn.off .pulse-marker,
+.mode-filter-btn.off .active-pulse-marker {
+    filter: grayscale(100%) brightness(40%);
+}
+
 /* Hide any legacy switches still in DOM */
 #menu .switch,
 #menu .switch-label { display: none !important; }


### PR DESCRIPTION
## Summary
- add horizontal mode filter panel between Filters and Upload buttons
- allow toggling New, Data, CW, SSB, and Unknown/QRT spot pulses
- style mode filter panel and update marker rendering to honor selections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ccc68ec50832a8705101d65600a9b