### PR TITLE
feat: highlight parks with reviews

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -338,7 +338,7 @@
 
 /* Highlight parks that have PN&R reviews */
 .leaflet-marker-icon.has-review {
-    box-shadow: 0 0 0 3px lightblue, 0 0 0 5px black;
+    box-shadow: 0 0 0 1.5px rgba(255, 215, 0, 0.95), 0 0 0 2.5px rgba(0, 0, 0, 0.9);
     border-radius: 50%;
 }
 


### PR DESCRIPTION
## Summary
- draw decorative review halos around all marker types
- preload cached review URLs before map setup to avoid initialization flash
- keep review halos when parks are redrawn or spotted
- shrink review halos for a subtler gold ring around review-linked parks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a730ee9e3c832abec81eec3290aa02