### PR TITLE
Fix mobile popup closing during viewport resize

### DIFF
--- a/scripts2.js
+++ b/scripts2.js
@@ -30,6 +30,7 @@ async function ensureModesInitOnce() {
 // Initialize global variables
 let activations = [];
 let map; // Leaflet map instance
+let isPopupOpen = false; // Tracks whether a map popup is currently open
 let parks = []; // Global variable to store parks data
 let userLat = null;
 let userLng = null;
@@ -3836,7 +3837,8 @@ function initializeMap(lat, lng) {
 
     // Attach dynamic spot fetching to map movement
     let skipNextSpotFetch = false;
-    mapInstance.on("popupopen", () => { skipNextSpotFetch = true; });
+    mapInstance.on("popupopen", () => { skipNextSpotFetch = true; isPopupOpen = true; });
+    mapInstance.on("popupclose", () => { isPopupOpen = false; });
     if (!isDesktopMode) {
         mapInstance.on(
             "moveend",
@@ -5096,7 +5098,9 @@ window.addEventListener('resize', debounce(() => {
     if (map) {
         map.invalidateSize();
         console.log("Map size invalidated on window resize.");
-        applyActivationToggleState();
+        if (!isPopupOpen) {
+            applyActivationToggleState();
+        }
     }
 }, 300));
 


### PR DESCRIPTION
## Summary
- Track open popups and skip refreshing markers during window resize
- Avoid closing detail popups on mobile when map shifts to accommodate them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76581b13c832a82293922571146c0