### PR TITLE
Add global REF PQL filter

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -66,6 +66,12 @@
     animation: none !important;
     -webkit-animation: none !important;
 }
+
+/* Ensure PQL highlight pulses render behind standard markers */
+.pql-pulse-icon {
+    pointer-events: none;
+    z-index: 0;
+}
 /* Desktop mode: shrink mode filter dots by ~20% */
 .desktop-mode .mode-dot {
     width: 28px;   /* was 34px */


### PR DESCRIPTION
## Summary
- support `REF`, `REFERENCE`, and `ID` PQL filters to match park references globally
- center map on matched park(s) at current zoom without altering zoom level
- ensure PQL highlight pulse icons render behind standard markers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8cc2f7174832abca52c2e2b5ed5af