### PR TITLE
Fix mobile park popups and auto-pan near edges

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -395,3 +395,12 @@
     .mode-dot{ width: 24px; height: 24px; }
     .mode-dot svg{ width: 16px; height: 16px; }
 }
+
+/* Ensure Leaflet popups fit and wrap on small screens */
+.leaflet-popup-content-wrapper{
+    max-width: 280px;
+}
+
+.leaflet-popup-content{
+    overflow-wrap: break-word;
+}

--- a/scripts2.js
+++ b/scripts2.js
@@ -57,6 +57,37 @@ let previousMapState = {
 // Fast rendering path
 let __canvasRenderer = null; // initialized after map setup
 let __panInProgress = false; // suppress redraws while panning
+let __skipNextMarkerRefresh = false; // skip refresh after programmatic pan
+
+/**
+ * Opens a marker's popup, panning the map first if the marker is too close
+ * to the edge of the current viewport.  This keeps popups reachable and
+ * prevents them from immediately closing when near map boundaries.
+ * @param {L.Marker} marker - Leaflet marker with a bound popup
+ */
+function openPopupWithAutoPan(marker) {
+    if (!map || !marker) return;
+    const latlng = marker.getLatLng();
+    const mapSize = map.getSize();
+    const point = map.latLngToContainerPoint(latlng);
+    const padding = 120; // space in px to keep around the popup
+    const needsPan =
+        point.x < padding || point.x > mapSize.x - padding ||
+        point.y < padding || point.y > mapSize.y - padding;
+
+    if (needsPan) {
+        __skipNextMarkerRefresh = true;
+        if (typeof map.panInside === 'function') {
+            map.panInside(latlng, { padding: [padding, padding], animate: true });
+            map.once('moveend', () => marker.openPopup());
+        } else {
+            map.once('moveend', () => marker.openPopup());
+            map.panTo(latlng, { animate: true });
+        }
+    } else {
+        marker.openPopup();
+    }
+}
 
 // --- Lightweight Toast UI -------------------------------------------------
 function ensureToastCss() {
@@ -848,7 +879,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             map.on('zoomstart', () => { __panInProgress = true; });
             const debouncedMoveEnd = (function(){
                 let t = null;
-                return () => { clearTimeout(t); t = setTimeout(() => { __panInProgress = false; refreshMarkers(); }, 120); };
+                return () => {
+                    clearTimeout(t);
+                    t = setTimeout(() => {
+                        __panInProgress = false;
+                        if (__skipNextMarkerRefresh) {
+                            __skipNextMarkerRefresh = false;
+                        } else {
+                            refreshMarkers();
+                        }
+                    }, 120);
+                };
             })();
             map.on('moveend', debouncedMoveEnd);
             map.on('zoomend', debouncedMoveEnd);
@@ -1272,7 +1313,7 @@ async function redrawMarkersWithFilters() {
 
             marker
                 .addTo(map.activationsLayer)
-                .bindPopup("<b>Loading park info...</b>", {keepInView: true, autoPan: true, autoPanPadding: [40, 40]})
+                .bindPopup("<b>Loading park info...</b>", {keepInView: false, autoPan: false})
                 .bindTooltip(tooltipText, {direction: "top", opacity: 0.9, sticky: false, className: "custom-tooltip"})
                 .on('click', function () {
                     this.closeTooltip();
@@ -3037,10 +3078,14 @@ function handleSearchInput(event) {
             className: 'custom-tooltip'
         });
 
-        marker.on('click', async () => {
+        const showPopup = async (e) => {
+            if (e) L.DomEvent.stop(e);
             const popupContent = await fetchFullPopupContent(park);
-            marker.bindPopup(popupContent).openPopup();
-        });
+            marker.bindPopup(popupContent, { autoPan: false });
+            openPopupWithAutoPan(marker);
+        };
+        marker.on('click', showPopup);
+        marker.on('touchend', showPopup);
     });
 }
 
@@ -3208,7 +3253,7 @@ async function zoomToPark(park) {
         // Ensure the popup is bound (it should be, from your displayParksOnMap or fetchAndDisplaySpots function)
         if (foundMarker._popup) {
             // This will automatically trigger the 'popupopen' event if you have it set
-            foundMarker.openPopup();
+            openPopupWithAutoPan(foundMarker);
             console.log(`Opened popup for existing marker of park ${park.reference}.`);
         } else {
             console.warn(`Marker has no bound popup for ${park.reference}.`);
@@ -3369,7 +3414,7 @@ function zoomToParks(parks) {
         map.activationsLayer.eachLayer(layer => {
             const layerLatLng = layer.getLatLng();
             if (layerLatLng.lat === park.latitude && layerLatLng.lng === park.longitude) {
-                layer.openPopup();
+                openPopupWithAutoPan(layer);
             }
         });
     });
@@ -4561,13 +4606,10 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
         marker
             .addTo(layerGroup)
             .bindPopup("<b>Loading park info...</b>", {
-                // keep the popup fully in view
-                keepInView: true,
-                autoPan: true,
-                // add a little breathing room around the popup
-                autoPanPadding: [40, 40],
                 // cap its width on small screens
-                maxWidth: 280
+                maxWidth: 280,
+                autoPan: false,
+                keepInView: false
             })
 
             .bindTooltip(tooltipText, {
@@ -4575,10 +4617,15 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
                 opacity: 0.9,
                 sticky: false,
                 className: "custom-tooltip",
-            })
-            .on('click', function () {
-                this.closeTooltip();
             });
+
+        const handleMarkerTap = (e) => {
+            if (e) L.DomEvent.stop(e);
+            marker.closeTooltip();
+            openPopupWithAutoPan(marker);
+        };
+        marker.on('click', handleMarkerTap);
+        marker.on('touchend', handleMarkerTap);
 
         marker.on('popupopen', async function () {
             try {


### PR DESCRIPTION
## Summary
- pan map to keep popups in view before opening
- skip marker refresh after programmatic pan so popups stay open
- stop marker click events from bubbling and disable popup auto-pan
- constrain popup width and wrap content for stable mobile display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1abda10d8832ab10710287c80f3ae