### PR TITLE
Load mode-change data on startup with chunked updates

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -1,5 +1,19 @@
 /* potaMapStyles.css */
 
+/* Indicator while mode data updates */
+#mode-loading {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    z-index: 1000;
+    display: none;
+}
+
 /* ================= Pulsing markers ================= */
 
 /* Highlight used when "Go To Park" centers a search result */


### PR DESCRIPTION
## Summary
- Fetch mode-change feed during startup and apply updates in async chunks
- Remove redundant `detectModeChanges` and defer execution with `ensureModesInitOnce`
- Add indicator styling for background mode updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d68e15f4832a9f918a722d9b72ad