### PR TITLE
Improve saved search list styling

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -541,30 +541,13 @@
     border-color:#0f172a;
 }
 .ssp-list{ list-style:none; margin:0; padding:0; }
-.ssp-item{
-    display:flex; gap:8px; align-items:center;
-    padding:6px 0; border-bottom:1px solid #f1f5f9;
-}
-.ssp-item:last-child{ border-bottom:none; }
-.ssp-icon{ width:34px; }
-.ssp-name{
-    flex:1 1 auto; min-width:120px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
-    border-radius:6px; padding:2px 4px;
-}
-.ssp-name:focus{ outline:2px solid #94a3b8; background:#f8fafc; }
-.ssp-empty{ color:#64748b; padding:6px 0; }
-
-
 
 /* --- Saved Searches: single-row layout with right-aligned icons --- */
 .ssp-item{
     display:flex;
     align-items:center;
-    gap:8px;
     padding:6px 0;
     border-bottom:1px solid #f1f5f9;
-    flex-wrap: nowrap;
-    background: transparent;
 }
 .ssp-item:last-child{ border-bottom:none; }
 .ssp-name{
@@ -576,35 +559,35 @@
     border-radius:6px;
     padding:2px 4px;
     font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    font-weight: 600;                 /* bold, sans-serif */
-    font-size: 0.95rem;
+    font-weight:700;                  /* bold, sans-serif */
+    font-size:0.95rem;
     color:#183a2a;
-    background: transparent;
-    min-height: 20px;
+    background:transparent;
 }
+.ssp-name:focus{ outline:2px solid #94a3b8; background:#f8fafc; }
 .ssp-name:empty::before {
-    content: "(untitled)";
-    color: #9aa4b2;        /* muted grey */
-    font-weight: 500;
+    content:"(untitled)";
+    color:#9aa4b2;        /* muted grey */
+    font-weight:500;
 }
 .ssp-actions{
+    margin-left:auto;                 /* push icons to the right */
     display:flex;
     align-items:center;
-    gap:6px;
-    margin-left:auto;                 /* push icons to the right */
-    flex-wrap: nowrap;
+    gap:4px;                          /* tight icon group */
 }
-.ssp-actions > * { flex: 0 0 auto; }
+.ssp-actions > * { flex:0 0 auto; }
 .ssp-iconbtn{
     appearance:none;
     border:none;
     background:transparent;
-    padding:6px;
+    padding:4px;                      /* smaller click target */
     line-height:0;
-    border-radius:6px;
+    border-radius:4px;
     cursor:pointer;
     color:#1f4d2f;                    /* icon color */
 }
 .ssp-iconbtn:hover{ background:rgba(0,0,0,0.06); }
 .ssp-iconbtn:focus-visible{ outline:2px solid #1f4d2f; outline-offset:2px; }
-.ssp-iconbtn svg{ width:18px; height:18px; display:block; }
+.ssp-iconbtn svg{ width:16px; height:16px; display:block; }
+.ssp-empty{ color:#64748b; padding:6px 0; }

--- a/scripts2.js
+++ b/scripts2.js
@@ -5516,13 +5516,13 @@ function initializeFilterChips() {
 
             // Play button (run saved search)
             const runBtn = makeIconBtn('Run saved search',
-                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path d="M8 5v14l11-7z" fill="currentColor"></path></svg>'
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z" fill="currentColor"></path></svg>'
             );
             runBtn.addEventListener('click', () => runSavedEntry(e));
 
             // Share button (copy URL)
             const shareBtn = makeIconBtn('Copy shareable link',
-                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path d="M14 9V5l7 7-7 7v-4H6V9h8z" fill="currentColor"></path></svg>'
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 9V5l7 7-7 7v-4H6V9h8z" fill="currentColor"></path></svg>'
             );
             shareBtn.addEventListener('click', async () => {
                 const url = buildShareUrl(e);
@@ -5532,7 +5532,7 @@ function initializeFilterChips() {
 
             // Delete button
             const delBtn = makeIconBtn('Delete saved search',
-                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path d="M6 7h12l-1 14H7L6 7zm3-3h6l1 2H8l1-2z" fill="currentColor"></path></svg>'
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7h12l-1 14H7L6 7zm3-3h6l1 2H8l1-2z" fill="currentColor"></path></svg>'
             );
             delBtn.addEventListener('click', () => { deleteSavedSearch(e.id); renderSavedList(); });
 


### PR DESCRIPTION
## Summary
- Show saved search name in bold with Play, Share and Delete icons grouped on the right
- Reduce icon spacing and size for a compact single-row layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21b73c17c832aa734a43438591a47