### PR TITLE
Scope distance PQL queries globally

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -93,7 +93,7 @@
 /* Ensure PQL highlight pulses render behind standard markers */
 .pql-pulse-icon {
     pointer-events: none;
-    z-index: 0;
+    z-index: -1000;
 }
 /* Desktop mode: shrink mode filter dots by ~20% */
 .desktop-mode .mode-dot {

--- a/scripts2.js
+++ b/scripts2.js
@@ -1210,12 +1210,13 @@ function queryHasExplicitScope(parsed) {
     const s = (parsed.state || parsed.STATE || parsed.region || parsed.country || parsed.COUNTRY || parsed.ref || parsed.reference || parsed.id);
     if (s) return true;
     if (Array.isArray(parsed.refs) && parsed.refs.length > 0) return true;
+    if (parsed.minDist != null || parsed.maxDist != null) return true;
     // Some parsers return a list of filters; look for STATE:/COUNTRY:/REF:
     const filters = parsed.filters || parsed.terms || [];
     if (Array.isArray(filters)) {
         for (const f of filters) {
             const k = (f && (f.key || f.type || f.name || '')).toString().toUpperCase();
-            if (k === 'STATE' || k === 'COUNTRY' || k === 'REF' || k === 'REFERENCE' || k === 'ID') return true;
+            if (k === 'STATE' || k === 'COUNTRY' || k === 'REF' || k === 'REFERENCE' || k === 'ID' || k === 'MINDIST' || k === 'MAXDIST' || k === 'DIST') return true;
         }
     }
     // A meta flag can force global behavior


### PR DESCRIPTION
## Summary
- Treat MINDIST and MAXDIST filters as global-scope in PQL queries
- Keep PQL highlight pulses behind standard markers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f4b8d020832a9ea328c6ba38fe6a