### PR TITLE
Run saved searches immediately

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -591,6 +591,8 @@
     user-select:none;
 }
 .ssp-actions button{ width:auto !important; }  /* belt & suspenders */
+.ssp-playbtn{ color:#15803d; }
+.ssp-playbtn:hover{ background:rgba(21,128,61,0.1); }
 .ssp-iconbtn:hover{ background:rgba(0,0,0,0.06); }
 .ssp-iconbtn:focus-visible{ outline:2px solid #1f4d2f; outline-offset:2px; }
 .ssp-iconbtn svg{ width:18px; height:18px; display:block; }

--- a/scripts2.js
+++ b/scripts2.js
@@ -5617,23 +5617,23 @@ function initializeFilterChips() {
             }
         }
         const box = getSearchBoxEl();
-        if (box) box.value = entry.pql;
+        if (box) {
+            box.value = entry.pql;
+            box.focus();
+        }
         window.__pqlCurrent = entry.pql;
 
         try {
-            if (typeof window.runPQL === 'function') {
-                await window.runPQL(entry.pql);
+            if (typeof runPQL === 'function') {
+                await runPQL(entry.pql);
                 return;
             }
-            if (typeof window.handleSearchEnter === 'function') {
-                window.handleSearchEnter({
-                    key: 'Enter', preventDefault: () => {
-                    }
-                });
+            if (typeof handleSearchEnter === 'function') {
+                handleSearchEnter({key: 'Enter', preventDefault: () => {}});
                 return;
             }
-            if (typeof window.redrawMarkersWithFilters === 'function') {
-                await window.redrawMarkersWithFilters();
+            if (typeof redrawMarkersWithFilters === 'function') {
+                await redrawMarkersWithFilters();
                 return;
             }
         } catch (e) {
@@ -5697,6 +5697,7 @@ function initializeFilterChips() {
             const runBtn = makeIconBtn('Run saved search',
                 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z" fill="currentColor"></path></svg>'
             );
+            runBtn.classList.add('ssp-playbtn');
             runBtn.addEventListener('click', () => window.runSavedEntry(e));
 
             // Share button (copy URL)


### PR DESCRIPTION
## Summary
- Ensure Play button on saved searches executes the query right away
- Focus search box and call search handlers directly
- Style Play button to indicate action

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f7dd3d00832a8fd5db5b7cad444c