### PR TITLE
Run saved searches immediately

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -591,6 +591,8 @@
     user-select:none;
 }
 .ssp-actions button{ width:auto !important; }  /* belt & suspenders */
+.ssp-playbtn{ color:#15803d; }
+.ssp-playbtn:hover{ background:rgba(21,128,61,0.1); }
 .ssp-iconbtn:hover{ background:rgba(0,0,0,0.06); }
 .ssp-iconbtn:focus-visible{ outline:2px solid #1f4d2f; outline-offset:2px; }
 .ssp-iconbtn svg{ width:18px; height:18px; display:block; }

--- a/scripts2.js
+++ b/scripts2.js
@@ -3945,6 +3945,13 @@ async function runPQL(raw, ctx = {}) {
         fitToMatchesIfGlobalScope(parsed, matched);
         updateMapWithFilteredParks(matched);
 
+        // Ensure matched parks are visibly highlighted
+        try {
+            applyPqlFilterDisplay(matched);
+        } catch (e) {
+            console.warn('applyPqlFilterDisplay failed', e);
+        }
+
         return matched;
     } catch (e) {
         console.warn('runPQL failed:', e);
@@ -5617,7 +5624,10 @@ function initializeFilterChips() {
             }
         }
         const box = getSearchBoxEl();
-        if (box) box.value = entry.pql;
+        if (box) {
+            box.value = entry.pql;
+            box.focus();
+        }
         window.__pqlCurrent = entry.pql;
 
         try {
@@ -5625,19 +5635,8 @@ function initializeFilterChips() {
                 await window.runPQL(entry.pql);
                 return;
             }
-            if (typeof window.handleSearchEnter === 'function') {
-                window.handleSearchEnter({
-                    key: 'Enter', preventDefault: () => {
-                    }
-                });
-                return;
-            }
-            if (typeof window.redrawMarkersWithFilters === 'function') {
-                await window.redrawMarkersWithFilters();
-                return;
-            }
         } catch (e) {
-            console.warn('runSavedEntry direct call failed, falling back to Enter-dispatch', e);
+            console.warn('runSavedEntry runPQL failed', e);
         }
 
         try {
@@ -5697,6 +5696,7 @@ function initializeFilterChips() {
             const runBtn = makeIconBtn('Run saved search',
                 '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z" fill="currentColor"></path></svg>'
             );
+            runBtn.classList.add('ssp-playbtn');
             runBtn.addEventListener('click', () => window.runSavedEntry(e));
 
             // Share button (copy URL)


### PR DESCRIPTION
## Summary
- Ensure Play button on saved searches executes the query right away
- Highlight matched parks after running saved PQL queries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f7dd3d00832a8fd5db5b7cad444c