### PR TITLE
Fix non-clickable spots after mobile searches

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -19,7 +19,8 @@
 
 /* Highlight used when "Go To Park" centers a search result */
 .goto-park-highlight {
-    pointer-events: none;
+    /* Ensure search highlights never intercept taps/clicks */
+    pointer-events: none !important;
 }
 
 .pulse-marker {

--- a/scripts2.js
+++ b/scripts2.js
@@ -2786,22 +2786,15 @@ function handleSearchInput(event) {
             color: '#000',
             weight: 2,
             opacity: 1,
-            fillOpacity: 0.8
+            fillOpacity: 0.8,
+            // Prevent highlight markers from blocking interaction with underlying spots
+            interactive: false,
+            bubblingMouseEvents: false
         }).addTo(map.highlightLayer);
 
-        marker.bindTooltip(`${park.name} (${park.reference})`, {
-            direction: 'top',
-            className: 'custom-tooltip'
-        });
-
-        const showPopup = async (e) => {
-            if (e) L.DomEvent.stop(e);
-            const popupContent = await fetchFullPopupContent(park);
-            marker.bindPopup(popupContent, {autoPan: true, autoPanPadding: [20, 20]});
-            openPopupWithAutoPan(marker);
-        };
-        marker.on('click touchend', showPopup);
-        marker.on('touchend', showPopup);
+        // The highlight is purely visual; the actual spot marker underneath
+        // remains fully interactive. Tooltips/popup handling are therefore
+        // unnecessary on this overlay marker.
     });
 }
 


### PR DESCRIPTION
## Summary
- Ensure search highlight markers do not block underlying spot taps by making them non-interactive
- Force search highlight styling to ignore pointer events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30c4cf248832a8e1f4a64bc05ef04