### PR TITLE
Fix mobile layer cleanup after PQL clear

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -670,6 +670,11 @@
     z-index: 450 !important; /* below Leaflet's marker pane (600) */
 }
 
+#pqlOverlayPane *,
+#searchHighlightPane * {
+    pointer-events: none !important;
+}
+
 /* Any ad-hoc highlight circles/paths should never eat events */
 .goto-park-highlight,
 .goto-park-highlight * {

--- a/scripts2.js
+++ b/scripts2.js
@@ -668,6 +668,10 @@ function clearPqlFilterDisplay() {
         P.highlightLayer.clearLayers();
         if (map.hasLayer(P.highlightLayer)) map.removeLayer(P.highlightLayer);
     }
+    // Remove any leftover custom pane used for PQL overlays so it can't block
+    // interaction (particularly on mobile where empty SVG panes may intercept taps)
+    const pane = map.getPane && map.getPane('pqlOverlayPane');
+    if (pane) pane.remove();
     map._pql = {};
 }
 


### PR DESCRIPTION
## Summary
- Ensure PQL overlay pane is removed on clearSearch to prevent invisible layer from intercepting taps
- Disable pointer events on all children of PQL and search highlight panes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3369f0524832a8613bc190b8141bc