### PR TITLE
Ensure Clear Search button persists after clearing

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -492,7 +492,7 @@
 }
 
 #clearSearch {
-    display: block;
+    display: block !important;
     width: 100%;
     padding: 10px;
     font-size: 16px;

--- a/scripts2.js
+++ b/scripts2.js
@@ -3917,13 +3917,10 @@ function setupSearchBoxListeners() {
         return;
     }
 
-    // Show the Clear button only when there is input
+    // Keep the Clear button visible regardless of input state
     searchBox.addEventListener('input', () => {
-        if (searchBox.value.trim() !== '') {
-            clearButton.style.display = 'block';
-        } else {
-            clearButton.style.display = 'none';
-        }
+        // Always show the Clear button so it doesn't disappear after use
+        clearButton.style.display = 'block';
     });
 
     // Attach the Clear button functionality


### PR DESCRIPTION
## Summary
- Prevent Clear Search button from hiding when search input is empty
- Force Clear Search button to remain visible via CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b369e93008832aa9d2a35ff16a48b4