### PR TITLE
Ensure initial park popups use collapsible panels

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -693,14 +693,17 @@
     pointer-events: none !important;
 }
 /* === Popup collapsibles (Recent / Current Activation) === */
+
 .leaflet-popup-content details.popup-collapsible {
-    margin: 8px 0 12px;
+    margin: 6px 0 6px;
     padding: 0;
     border: 1px solid rgba(0,0,0,0.15);
     border-radius: 6px;
     background: #fafafa;
     overflow: hidden;
 }
+.leaflet-popup-content details.popup-collapsible:first-of-type { margin-top: 4px; }
+.leaflet-popup-content details.popup-collapsible:last-of-type { margin-bottom: 4px; }
 
 .leaflet-popup-content details.popup-collapsible > summary {
     cursor: pointer;

--- a/scripts2.js
+++ b/scripts2.js
@@ -4630,6 +4630,8 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
                 await saveParkActivationsToIndexedDB(reference, parkActivations);
 
                 let popupContent = await fetchFullPopupContent(park, currentActivation, parkActivations);
+                // Ensure the popup uses collapsible panels for activation sections
+                popupContent = foldPopupSections(popupContent);
 
                 if (park.change) {
                     popupContent += `


### PR DESCRIPTION
## Summary
- Always fold park popups into collapsible panels during initial map load
- Style popup panels and tweak margins so the first/last panels have tighter spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a94c8a10832aa35766056bbee999