### PR TITLE
Ensure initial park popups use collapsible panels

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -693,14 +693,17 @@
     pointer-events: none !important;
 }
 /* === Popup collapsibles (Recent / Current Activation) === */
+
 .leaflet-popup-content details.popup-collapsible {
-    margin: 8px 0 12px;
+    margin: 6px 0 6px;
     padding: 0;
     border: 1px solid rgba(0,0,0,0.15);
     border-radius: 6px;
     background: #fafafa;
     overflow: hidden;
 }
+.leaflet-popup-content details.popup-collapsible:first-of-type { margin-top: 4px; }
+.leaflet-popup-content details.popup-collapsible:last-of-type { margin-bottom: 4px; }
 
 .leaflet-popup-content details.popup-collapsible > summary {
     cursor: pointer;
@@ -730,6 +733,9 @@
     padding: 8px 10px 10px;
     border-top: 1px solid rgba(0,0,0,0.08);
     background: #fff;
+}
+.leaflet-popup-content details.popup-collapsible.recent-activations .popup-collapsible-body {
+    font-size: 0.9em;
 }
 @media (max-width: 480px) {
     .leaflet-popup-content details.popup-collapsible { margin: 6px 0 10px; }

--- a/scripts2.js
+++ b/scripts2.js
@@ -322,6 +322,11 @@ function foldPopupSections(html) {
         function makeDetailsFromBold(boldEl, titleText) {
             const details = document.createElement('details'); // closed by default
             details.className = 'popup-collapsible';
+            if (titleText === 'Recent Activations') {
+                details.classList.add('recent-activations');
+            } else if (titleText === 'Current Activation') {
+                details.classList.add('current-activation');
+            }
 
             const summary = document.createElement('summary');
             summary.textContent = titleText;
@@ -1748,6 +1753,9 @@ function refreshMarkers() {
     if (typeof suppressRedrawUntil !== 'undefined' && Date.now() < suppressRedrawUntil) {
         return;
     }
+    if (__skipNextMarkerRefresh) {
+        return;
+    }
 
 
     /** Robustly find a park's marker by reference, searching common layer groups. */
@@ -1837,11 +1845,6 @@ function refreshMarkers() {
         } else {
             console.warn("openParkPopupByRef: marker not found for", reference);
         }
-    }
-
-// Avoid redraws while a popup is open (prevents immediate close after auto-pan)
-    if (typeof isPopupOpen !== 'undefined' && isPopupOpen) {
-        return;
     }
     if (MODE_CHANGES_AVAILABLE && typeof updateVisibleModeCounts === 'function') {
         updateVisibleModeCounts();
@@ -2616,10 +2619,10 @@ function formatQsoDate(qsoDate) {
         const day = qsoDate.substring(6, 8);
         date = new Date(`${year}-${month}-${day}`);
     }
-    return date.toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric'
+    return date.toLocaleDateString('en-US', {
+        year: '2-digit',
+        month: '2-digit',
+        day: '2-digit'
     });
 }
 
@@ -4459,26 +4462,29 @@ function initializeMap(lat, lng) {
 
     // Attach dynamic spot fetching to map movement
     let skipNextSpotFetch = false;
+    const debouncedSpotFetch = debounce(() => {
+        console.log("Map moved or zoomed. Updating spots...");
+        fetchAndDisplaySpotsInCurrentBounds(mapInstance)
+            .then(() => applyActivationToggleState());
+    }, 300);
     mapInstance.on("popupopen", () => {
         skipNextSpotFetch = true;
         isPopupOpen = true;
+        __skipNextMarkerRefresh = true;
     });
     mapInstance.on("popupclose", () => {
         isPopupOpen = false;
+        skipNextSpotFetch = false;
+        __skipNextMarkerRefresh = false;
     });
     if (!isDesktopMode) {
-        mapInstance.on(
-            "moveend",
-            debounce(() => {
-                if (skipNextSpotFetch) {
-                    skipNextSpotFetch = false;
-                    return;
-                }
-                console.log("Map moved or zoomed. Updating spots...");
-                fetchAndDisplaySpotsInCurrentBounds(mapInstance)
-                    .then(() => applyActivationToggleState());
-            }, 300)
-        );
+        mapInstance.on("moveend", () => {
+            if (skipNextSpotFetch) {
+                skipNextSpotFetch = false;
+                return;
+            }
+            debouncedSpotFetch();
+        });
     }
 
     return mapInstance;
@@ -4630,6 +4636,8 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
                 await saveParkActivationsToIndexedDB(reference, parkActivations);
 
                 let popupContent = await fetchFullPopupContent(park, currentActivation, parkActivations);
+                // Ensure the popup uses collapsible panels for activation sections
+                popupContent = foldPopupSections(popupContent);
 
                 if (park.change) {
                     popupContent += `


### PR DESCRIPTION
## Summary
- Always fold park popups into collapsible panels during initial map load
- Style popup panels with tighter margins and smaller Recent Activations text
- Format recent activation dates as MM/DD/YY
- Refresh map spots even when popups stay open and clear popup state on close
- Skip marker refresh during auto-pan so popups stay open when they adjust into view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a94c8a10832aa35766056bbee999