### PR TITLE
Fix popup autopan and restore geolocation centering

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -505,6 +505,7 @@
     padding: 10px;
     font-size: 16px;
     margin-top: 10px;
+    cursor: pointer;
 }
 
 #clearSearch i {


### PR DESCRIPTION
## Summary
- open popups after panning and refreshing markers, avoiding hard-coded delays
- restore "Center on My Location" by waiting for map readiness before centering
- ensure location button shows pointer cursor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9bcc0fba0832a9c3b5ca3c2a18e1d