### PR TITLE
Fix persistent highlighting for new parks

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -28,14 +28,15 @@
     pointer-events: none;
 }
 
+/* Purple highlight for newly added parks */
 .pulse-marker {
     pointer-events: none;
     width: 20px;
     height: 20px;
-    background-color: #800080;
+    background-color: #800080 !important;
     border-radius: 50%;
     border: 2px solid black;
-    box-shadow: 0 0 8px rgba(128, 0, 128, 0.7);
+    box-shadow: 0 0 8px rgba(128, 0, 128, 0.7) !important;
     opacity: 1;
     z-index: 1000;
     transform: translate(-10px, -10px);

--- a/scripts2.js
+++ b/scripts2.js
@@ -1644,8 +1644,8 @@ async function redrawMarkersWithFilters() {
             // Use recent-adds set instead of created timestamp
             const RECENT = (window.__RECENT_ADDS instanceof Set) ? window.__RECENT_ADDS : new Set();
             const isNew = RECENT.has(reference);
-            // Gate the purple highlighting behind the New filter chip
-            const showNewColor = !!potaFilters?.newParks && isNew;
+            // Always show purple highlight for parks recently added to the system
+            const showNewColor = isNew;
             const currentActivation = spotByRef[reference];
             const isActive = !!currentActivation;
             const mode = currentActivation?.mode ? currentActivation.mode.toUpperCase() : '';
@@ -1695,7 +1695,7 @@ async function redrawMarkersWithFilters() {
                 }
             } else {
                 const baseColor = getMarkerColorConfigured(parkActivationCount, isUserActivated);
-                const fillColor = showNewColor ? "#800080" : baseColor; // purple only when New filter ON and truly new
+                const fillColor = showNewColor ? "#800080" : baseColor; // purple for newly added parks
                 marker = L.circleMarker([latitude, longitude], {
                     renderer: __canvasRenderer || undefined,
                     radius: 6,


### PR DESCRIPTION
## Summary
- Ensure recently added parks always render with a purple pulse marker
- Harden CSS styles for new park highlights

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9ca5442b0832a98dccedc6436b3e6