### PR TITLE
Fix mobile marker tap handling

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -97,6 +97,23 @@
     -webkit-animation: none !important;
 }
 
+/* Ensure interactive park markers remain tappable even when pulsing */
+.leaflet-marker-icon.park-spot-icon {
+    pointer-events: auto;
+    touch-action: manipulation;
+    cursor: pointer;
+}
+
+.leaflet-marker-icon.park-spot-icon.pulse-marker,
+.leaflet-marker-icon.park-spot-icon.active-pulse-marker {
+    pointer-events: auto;
+}
+
+.desktop-mode .leaflet-marker-icon.park-spot-icon.pulse-marker,
+.desktop-mode .leaflet-marker-icon.park-spot-icon.active-pulse-marker {
+    pointer-events: auto;
+}
+
 /* Ensure PQL highlight pulses render behind standard markers */
 .pql-pulse-icon {
     pointer-events: none;

--- a/scripts2.js
+++ b/scripts2.js
@@ -1679,10 +1679,13 @@ async function redrawMarkersWithFilters() {
             let marker;
             const usingDivIcon = markerClasses.length > 0;
             if (usingDivIcon) {
+                const iconClasses = ['leaflet-div-icon', 'park-spot-icon'];
+                if (markerClassName) iconClasses.push(markerClassName);
                 marker = L.marker([latitude, longitude], {
+                    interactive: true,
                     icon: L.divIcon({
                         // include Leaflet's default class for compatibility with Leaflet styles
-                        className: `leaflet-div-icon ${markerClassName}`.trim(),
+                        className: iconClasses.join(' '),
                         iconSize: [20, 20],
                     })
                 });
@@ -4641,8 +4644,9 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
         const baseColor = getMarkerColorConfigured(parkActivationCount, isUserActivated, created);
         const marker = useDivIcon
             ? L.marker([latitude, longitude], {
+                interactive: true,
                 icon: L.divIcon({
-                    className: `leaflet-div-icon ${markerClassName}`.trim(),
+                    className: ['leaflet-div-icon', 'park-spot-icon', markerClassName].filter(Boolean).join(' '),
                     iconSize: [20, 20],
                 })
             })


### PR DESCRIPTION
## Summary
- ensure pulsing divIcon markers include a dedicated class and remain interactive when rendered
- allow park marker icons to keep pointer events so taps open popups on touch devices

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3f1f60b94832a8ce21a6a9e4a847e