### PR TITLE
Add park notes support to park popups

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -497,6 +497,149 @@
     overflow-wrap: break-word;
 }
 
+/* Flip card popup for personal park notes */
+.leaflet-popup-content .park-popup-card {
+    position: relative;
+    perspective: 1400px;
+    min-height: 180px;
+}
+
+.park-popup-inner {
+    position: relative;
+    width: 100%;
+    transition: transform 0.48s ease;
+    transform-style: preserve-3d;
+}
+
+.park-popup-card.is-flipped .park-popup-inner {
+    transform: rotateY(180deg);
+}
+
+.park-popup-face {
+    position: relative;
+    background: #fff;
+    backface-visibility: hidden;
+    min-height: 180px;
+    padding-top: 10px;
+}
+
+.park-popup-front-body,
+.park-popup-back-body {
+    padding: 0 4px 6px;
+}
+
+.park-popup-face.park-popup-back {
+    transform: rotateY(180deg);
+}
+
+.park-popup-corner-toggle {
+    position: absolute;
+    top: -14px;
+    right: -14px;
+    width: 42px;
+    height: 42px;
+    border: none;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #1d4ed8, #2563eb);
+    color: #fff;
+    cursor: pointer;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.28);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: rotate(45deg);
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+    z-index: 2;
+}
+
+.park-popup-corner-toggle > span {
+    transform: rotate(-45deg);
+    font-size: 18px;
+    line-height: 1;
+}
+
+.park-popup-corner-toggle:hover,
+.park-popup-corner-toggle:focus-visible {
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.35);
+}
+
+.park-popup-corner-toggle:focus-visible {
+    outline: 2px solid #facc15;
+    outline-offset: 4px;
+}
+
+.park-popup-corner-toggle.back {
+    background: linear-gradient(135deg, #334155, #1f2937);
+}
+
+.park-popup-card.has-note .park-popup-corner-toggle.front {
+    background: linear-gradient(135deg, #047857, #059669);
+}
+
+.park-popup-notes-label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-weight: 600;
+}
+
+.park-popup-notes-textarea {
+    width: 100%;
+    min-height: 140px;
+    padding: 10px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    resize: vertical;
+    font-family: inherit;
+    font-size: 0.95rem;
+    line-height: 1.4;
+    box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.08);
+}
+
+.park-popup-notes-textarea:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+    outline: none;
+}
+
+.park-popup-note-hint {
+    margin-top: 6px;
+    font-size: 0.75rem;
+    color: #4b5563;
+}
+
+.park-popup-note-status {
+    margin-top: 4px;
+    font-size: 0.78rem;
+    min-height: 1em;
+    color: #2563eb;
+}
+
+.park-popup-card.has-note .park-popup-note-status {
+    color: #047857;
+}
+
+.park-popup-note-status.error {
+    color: #b91c1c;
+}
+
+@media (max-width: 420px) {
+    .park-popup-corner-toggle {
+        top: -12px;
+        right: -12px;
+        width: 36px;
+        height: 36px;
+    }
+
+    .park-popup-corner-toggle > span {
+        font-size: 16px;
+    }
+
+    .park-popup-notes-textarea {
+        min-height: 120px;
+    }
+}
+
 #searchBoxContainer {
     position: relative;
     width: 100%;

--- a/scripts2.js
+++ b/scripts2.js
@@ -39,6 +39,9 @@ function whenMapReady(cb) {
 let __popupLockUntil = 0;
 let __popupStabilityMode = false;
 
+let __parkNotesState = null;       // {map: Map<REF, {note, updated}>, set: Set<REF>}
+let __parkNotesStatePromise = null;
+
 function lockPopupRefresh(ms = 900) {
     __popupLockUntil = Date.now() + ms;
     __popupStabilityMode = true;
@@ -619,6 +622,9 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
     // Clear existing markers
     layerGroup.clearLayers();
 
+    const notesState = await ensureNotesCacheFromIndexedDB();
+    const notesRefs = notesState?.set || new Set();
+
     // Build an index of current spots by reference for “currently on air”
     const spotByRef = {};
     for (const s of asArray(spots)) {
@@ -629,6 +635,8 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
         const { reference, name, latitude, longitude, activations: parkActivationCount, created } = park;
         if (!latitude || !longitude) continue;
 
+        const refKey = normalizeNoteRef(reference);
+
         // Determine state flags
         const isUserActivated = Array.isArray(userActivatedReferences) && userActivatedReferences.includes(reference);
         const createdTime = created ? (typeof created === 'number' ? created : new Date(created).getTime()) : null;
@@ -637,6 +645,10 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
         const currentActivation = spotByRef[reference];
         const isActive = !!currentActivation;
         const mode = currentActivation?.mode?.toUpperCase() || '';
+        const hasNote = notesRefs.has(refKey);
+
+        if (hasNote) park.__hasNotes = true;
+        else if (park.__hasNotes) delete park.__hasNotes;
 
         // Filter by user toggles
         if (!shouldDisplayParkFlags({ isUserActivated, isActive, isNew })) continue;
@@ -660,6 +672,9 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
                     iconSize: [20, 20],
                 })
             });
+            if (hasNote) {
+                decorateNotesHalo(marker);
+            }
         } else {
             const fillColor = isNew ? "#800080" : getMarkerColorConfigured(parkActivationCount, isUserActivated);
             marker = L.circleMarker([latitude, longitude], {
@@ -671,6 +686,9 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
                 opacity: 1,
                 fillOpacity: 0.9,
             });
+            if (hasNote) {
+                decorateNotesHalo(marker);
+            }
         }
 
         // Tooltip text
@@ -700,7 +718,13 @@ async function displayParksOnMap(map, parks, userActivatedReferences = null, lay
 
                 let popupContent = await fetchFullPopupContent(park, currentActivation, parkActivations);
                 popupContent = foldPopupSections(popupContent);
-                this.setPopupContent(popupContent);
+                const card = await buildPopupWithNotes({
+                    reference,
+                    frontHtml: popupContent,
+                    marker: this,
+                    parkRecord: park
+                });
+                this.setPopupContent(card);
             } catch (err) {
                 console.error(err);
                 this.setPopupContent("<b>Error loading park info.</b>");
@@ -1238,6 +1262,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         ensureReviewHaloCss();
 
         await ensureReviewCacheFromIndexedDB();
+        await ensureNotesCacheFromIndexedDB();
         // Load true new-park refs from changes.json to avoid mass purple due to drifting 'created'
         try {
             await ensureRecentAddsFromChangesJSON();
@@ -1734,6 +1759,242 @@ function decorateReviewHalo(marker, park) {
     }
 }
 
+function normalizeNoteRef(reference) {
+    return String(reference || '').trim().toUpperCase();
+}
+
+async function ensureNotesCacheFromIndexedDB() {
+    if (__parkNotesState) return __parkNotesState;
+    if (__parkNotesStatePromise) return __parkNotesStatePromise;
+
+    __parkNotesStatePromise = (async () => {
+        const state = {map: new Map(), set: new Set()};
+
+        if (typeof indexedDB === 'undefined') {
+            __parkNotesState = state;
+            return state;
+        }
+
+        try {
+            const db = await getDatabase();
+            if (!db.objectStoreNames.contains('parkNotes')) {
+                __parkNotesState = state;
+                return state;
+            }
+
+            const records = await new Promise((resolve, reject) => {
+                try {
+                    const tx = db.transaction('parkNotes', 'readonly');
+                    const store = tx.objectStore('parkNotes');
+                    if (typeof store.getAll === 'function') {
+                        const req = store.getAll();
+                        req.onsuccess = () => resolve(req.result || []);
+                        req.onerror = (e) => reject(e.target.error);
+                    } else {
+                        const rows = [];
+                        const req = store.openCursor();
+                        req.onsuccess = (event) => {
+                            const cursor = event.target.result;
+                            if (cursor) {
+                                rows.push(cursor.value);
+                                cursor.continue();
+                            } else {
+                                resolve(rows);
+                            }
+                        };
+                        req.onerror = (e) => reject(e.target.error);
+                    }
+                } catch (err) {
+                    reject(err);
+                }
+            });
+
+            for (const row of records) {
+                if (!row || typeof row !== 'object') continue;
+                const ref = normalizeNoteRef(row.reference);
+                const noteRaw = row.note;
+                const note = typeof noteRaw === 'string' ? noteRaw : (noteRaw == null ? '' : String(noteRaw));
+                const trimmed = note.trim();
+                if (!ref || !trimmed) continue;
+                state.map.set(ref, {note: trimmed, updated: row.updated || 0});
+                state.set.add(ref);
+            }
+        } catch (e) {
+            console.warn('ensureNotesCacheFromIndexedDB failed:', e);
+        }
+
+        __parkNotesState = state;
+        return state;
+    })();
+
+    try {
+        return await __parkNotesStatePromise;
+    } finally {
+        __parkNotesStatePromise = null;
+    }
+}
+
+function getCachedNoteForRef(reference) {
+    if (!__parkNotesState) return '';
+    const ref = normalizeNoteRef(reference);
+    const rec = __parkNotesState.map.get(ref);
+    return rec ? (rec.note || '') : '';
+}
+
+async function loadNoteForReference(reference) {
+    const state = await ensureNotesCacheFromIndexedDB();
+    if (!state) return '';
+    const ref = normalizeNoteRef(reference);
+    const rec = state.map.get(ref);
+    return rec ? (rec.note || '') : '';
+}
+
+async function saveParkNoteToIndexedDB(reference, note) {
+    if (!reference) return false;
+    const ref = normalizeNoteRef(reference);
+    const normalized = typeof note === 'string' ? note.trim() : String(note || '').trim();
+
+    await ensureNotesCacheFromIndexedDB();
+
+    if (typeof indexedDB === 'undefined') {
+        if (!__parkNotesState) __parkNotesState = {map: new Map(), set: new Set()};
+        if (normalized) {
+            __parkNotesState.map.set(ref, {note: normalized, updated: Date.now()});
+            __parkNotesState.set.add(ref);
+        } else {
+            __parkNotesState.map.delete(ref);
+            __parkNotesState.set.delete(ref);
+        }
+        return normalized.length > 0;
+    }
+
+    try {
+        const db = await getDatabase();
+        if (!db.objectStoreNames.contains('parkNotes')) {
+            if (!__parkNotesState) __parkNotesState = {map: new Map(), set: new Set()};
+            if (normalized) {
+                __parkNotesState.map.set(ref, {note: normalized, updated: Date.now()});
+                __parkNotesState.set.add(ref);
+            } else {
+                __parkNotesState.map.delete(ref);
+                __parkNotesState.set.delete(ref);
+            }
+            return normalized.length > 0;
+        }
+
+        await new Promise((resolve, reject) => {
+            const tx = db.transaction('parkNotes', 'readwrite');
+            const store = tx.objectStore('parkNotes');
+            if (normalized) {
+                const req = store.put({reference: ref, note: normalized, updated: Date.now()});
+                req.onsuccess = () => resolve();
+                req.onerror = (e) => reject(e.target.error);
+            } else {
+                const req = store.delete(ref);
+                req.onsuccess = () => resolve();
+                req.onerror = (e) => reject(e.target.error);
+            }
+        });
+    } catch (e) {
+        console.warn(`saveParkNoteToIndexedDB failed for ${ref}:`, e);
+        throw e;
+    }
+
+    if (!__parkNotesState) __parkNotesState = {map: new Map(), set: new Set()};
+    if (normalized) {
+        __parkNotesState.map.set(ref, {note: normalized, updated: Date.now()});
+        __parkNotesState.set.add(ref);
+    } else {
+        __parkNotesState.map.delete(ref);
+        __parkNotesState.set.delete(ref);
+    }
+
+    return normalized.length > 0;
+}
+
+function parkHasStoredNote(reference) {
+    if (!__parkNotesState) return false;
+    return __parkNotesState.set.has(normalizeNoteRef(reference));
+}
+
+function ensureNotesHaloPane() {
+    if (!map) return;
+    if (!map.getPane('notesHalos')) {
+        map.createPane('notesHalos');
+        const pane = map.getPane('notesHalos');
+        if (pane) pane.style.zIndex = 455;
+    }
+}
+
+function decorateNotesHalo(marker) {
+    if (!marker || marker.__notesHalos) return;
+    if (!map) return;
+
+    ensureNotesHaloPane();
+
+    const latLng = marker.getLatLng && marker.getLatLng();
+    if (!latLng) return;
+
+    let baseR;
+    if (marker.getRadius) {
+        baseR = marker.options?.radius || marker.getRadius();
+    } else if (marker.options?.icon?.options?.iconSize) {
+        baseR = marker.options.icon.options.iconSize[0] / 2;
+    } else {
+        baseR = 6;
+    }
+
+    const teal = L.circleMarker(latLng, {
+        pane: 'notesHalos',
+        radius: baseR + 5,
+        color: '#0f766e',
+        weight: 2,
+        fillOpacity: 0,
+        opacity: 0.95,
+        interactive: false
+    }).addTo(map.activationsLayer || map);
+
+    const navy = L.circleMarker(latLng, {
+        pane: 'notesHalos',
+        radius: baseR + 6,
+        color: '#022c22',
+        weight: 2,
+        fillOpacity: 0,
+        opacity: 1,
+        interactive: false
+    }).addTo(map.activationsLayer || map);
+
+    marker.__notesHalos = [navy, teal];
+    if (marker.on) {
+        marker.on('remove', () => removeNotesHalo(marker));
+    }
+}
+
+function removeNotesHalo(marker) {
+    if (!marker || !marker.__notesHalos) return;
+    const halos = marker.__notesHalos;
+    marker.__notesHalos = null;
+    for (const halo of halos) {
+        try {
+            if (halo && typeof halo.remove === 'function') {
+                halo.remove();
+            } else if (map && map.removeLayer) {
+                map.removeLayer(halo);
+            }
+        } catch (_) {
+        }
+    }
+}
+
+function updateMarkerNotesVisual(marker, hasNote) {
+    if (!marker) return;
+    if (hasNote) {
+        decorateNotesHalo(marker);
+    } else {
+        removeNotesHalo(marker);
+    }
+}
+
 // Lightweight refresh: clear and redraw current view using existing flow
 
 /* === Direct redraw path that respects potaFilters (Ada v7, patched for PN&R rings) === */
@@ -1755,6 +2016,9 @@ async function redrawMarkersWithFilters() {
         const bounds = getCurrentMapBounds();
         const userActivatedReferences = asArray(activations).map(a => a && a.reference).filter(Boolean);
 
+        const notesState = await ensureNotesCacheFromIndexedDB();
+        const notesRefs = notesState?.set || new Set();
+
         // Build a quick index for current spots by reference
         const spotByRef = {};
         if (Array.isArray(spots)) {
@@ -1775,6 +2039,8 @@ async function redrawMarkersWithFilters() {
             const latLng = L.latLng(latitude, longitude);
             if (!bounds.contains(latLng)) return;
 
+            const refKey = normalizeNoteRef(reference);
+
             const isUserActivated = userActivatedReferences.includes(reference);
             const RECENT = (window.__RECENT_ADDS instanceof Set) ? window.__RECENT_ADDS : new Set();
             let createdTime = null;
@@ -1786,6 +2052,10 @@ async function redrawMarkersWithFilters() {
             const currentActivation = spotByRef[reference];
             const isActive = !!currentActivation;
             const mode = currentActivation?.mode ? currentActivation.mode.toUpperCase() : '';
+            const hasNote = notesRefs.has(refKey);
+
+            if (hasNote) park.__hasNotes = true;
+            else if (park.__hasNotes) delete park.__hasNotes;
 
             if (!shouldDisplayParkFlags({isUserActivated, isActive, isNew})) return;
             if (!shouldDisplayByMode(isActive, isNew, mode)) return;
@@ -1830,6 +2100,9 @@ async function redrawMarkersWithFilters() {
                         decorateReviewHalo(marker, park);
                     }
                 }
+                if (hasNote) {
+                    decorateNotesHalo(marker);
+                }
             } else {
                 const baseColor = getMarkerColorConfigured(parkActivationCount, isUserActivated);
                 const fillColor = showNewColor ? "#800080" : baseColor; // purple for newly added parks
@@ -1851,6 +2124,9 @@ async function redrawMarkersWithFilters() {
                         park.reviewURL = u;
                         decorateReviewHalo(marker, park);
                     }
+                }
+                if (hasNote) {
+                    decorateNotesHalo(marker);
                 }
             }
 
@@ -1925,7 +2201,13 @@ async function redrawMarkersWithFilters() {
                     let popupContent = await fetchFullPopupContent(displayPark, currentActivation, parkActivations);
                     // Wrap "Recent Activations" and "Current Activation" in collapsible panels (closed by default)
                     popupContent = foldPopupSections(popupContent);
-                    this.setPopupContent(popupContent);
+                    const card = await buildPopupWithNotes({
+                        reference,
+                        frontHtml: popupContent,
+                        marker: this,
+                        parkRecord: park
+                    });
+                    this.setPopupContent(card);
                 } catch (err) {
                     this.setPopupContent("<b>Error loading park info.</b>");
                     console.error(err);
@@ -2486,7 +2768,7 @@ function enhanceHamburgerMenuForMobile() {
  */
 async function getDatabase() {
     return new Promise((resolve, reject) => {
-        const request = indexedDB.open('potaDatabase', 3); // Incremented version to add 'parkActivations' store
+        const request = indexedDB.open('potaDatabase', 4); // Incremented to add 'parkNotes' store
 
         request.onupgradeneeded = function (event) {
             const db = event.target.result;
@@ -2504,6 +2786,10 @@ async function getDatabase() {
             // Create object store for park activations if it doesn't exist
             if (!db.objectStoreNames.contains('parkActivations')) {
                 db.createObjectStore('parkActivations', {keyPath: 'reference'});
+            }
+
+            if (!db.objectStoreNames.contains('parkNotes')) {
+                db.createObjectStore('parkNotes', {keyPath: 'reference'});
             }
         };
 
@@ -3273,7 +3559,7 @@ function handleSearchInput(event) {
  * Handles the 'Enter' key press in the search box to zoom to the searched park(s).
  * @param {KeyboardEvent} event - The keyboard event triggered by key presses.
  */
-function handleSearchEnter(event) {
+async function handleSearchEnter(event) {
     if (event.key === 'Enter') {
         event.preventDefault(); // Prevent form submission or other default actions
         console.log("'Enter' key pressed in search box."); // Debugging
@@ -3310,7 +3596,9 @@ function handleSearchEnter(event) {
             const userActivatedRefs = (activations || []).map(a => a.reference);
             const now = Date.now();
             const nferByRef = buildNferByRef(parks);
-            const ctx = {bounds, spotByRef, spotByCall, userActivatedRefs, now, userLat, userLng, nferByRef};
+            const notesState = await ensureNotesCacheFromIndexedDB();
+            const notesRefs = notesState?.set || new Set();
+            const ctx = {bounds, spotByRef, spotByCall, userActivatedRefs, now, userLat, userLng, nferByRef, notesRefs};
 
             // Default scope: only parks inside current bounds
             const scoped = queryHasExplicitScope(parsed);
@@ -3553,6 +3841,197 @@ async function fetchFullPopupContent(park, currentActivation = null, parkActivat
     return popupContent.trim();
 }
 
+async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
+    const fallback = document.createElement('div');
+    fallback.innerHTML = frontHtml || '';
+
+    try {
+        const ref = normalizeNoteRef(reference);
+        const card = document.createElement('div');
+        card.className = 'park-popup-card';
+
+        const inner = document.createElement('div');
+        inner.className = 'park-popup-inner';
+        card.appendChild(inner);
+
+        const front = document.createElement('section');
+        front.className = 'park-popup-face park-popup-front';
+        inner.appendChild(front);
+
+        const frontToggle = document.createElement('button');
+        frontToggle.type = 'button';
+        frontToggle.className = 'park-popup-corner-toggle front';
+        frontToggle.setAttribute('aria-label', 'Add personal notes');
+        frontToggle.title = 'Add personal notes';
+        frontToggle.innerHTML = '<span aria-hidden="true">📝</span>';
+        front.appendChild(frontToggle);
+
+        const frontBody = document.createElement('div');
+        frontBody.className = 'park-popup-front-body';
+        frontBody.innerHTML = frontHtml || '';
+        front.appendChild(frontBody);
+
+        const back = document.createElement('section');
+        back.className = 'park-popup-face park-popup-back';
+        inner.appendChild(back);
+
+        const backToggle = document.createElement('button');
+        backToggle.type = 'button';
+        backToggle.className = 'park-popup-corner-toggle back';
+        backToggle.setAttribute('aria-label', 'Show park details');
+        backToggle.title = 'Show park details';
+        backToggle.innerHTML = '<span aria-hidden="true">↩</span>';
+        back.appendChild(backToggle);
+
+        const backBody = document.createElement('div');
+        backBody.className = 'park-popup-back-body';
+        back.appendChild(backBody);
+
+        const label = document.createElement('label');
+        label.className = 'park-popup-notes-label';
+        backBody.appendChild(label);
+
+        const labelText = document.createElement('span');
+        labelText.textContent = `Notes for ${reference}`;
+        label.appendChild(labelText);
+
+        const textarea = document.createElement('textarea');
+        textarea.className = 'park-popup-notes-textarea';
+        textarea.placeholder = 'Write your personal notes here…';
+        textarea.rows = 6;
+        textarea.spellcheck = true;
+        label.appendChild(textarea);
+
+        const hint = document.createElement('div');
+        hint.className = 'park-popup-note-hint';
+        hint.textContent = 'Notes stay on this device and are not shared.';
+        backBody.appendChild(hint);
+
+        const status = document.createElement('div');
+        status.className = 'park-popup-note-status';
+        status.setAttribute('aria-live', 'polite');
+        backBody.appendChild(status);
+
+        const state = await ensureNotesCacheFromIndexedDB();
+        const existing = state?.map?.get(ref);
+        const existingText = existing ? (existing.note || '') : '';
+        textarea.value = existingText;
+
+        const normalize = (value) => (typeof value === 'string' ? value.trim() : '');
+        let lastSavedNormalized = normalize(existingText);
+        if (lastSavedNormalized) {
+            card.classList.add('has-note');
+        }
+        if (marker) updateMarkerNotesVisual(marker, !!lastSavedNormalized);
+        if (parkRecord) {
+            if (lastSavedNormalized) parkRecord.__hasNotes = true;
+            else if (parkRecord.__hasNotes) delete parkRecord.__hasNotes;
+        }
+
+        const setStatus = (msg, isError = false) => {
+            if (!status) return;
+            status.textContent = msg || '';
+            status.classList.toggle('error', !!isError);
+        };
+
+        let saveTimer = null;
+
+        const persist = async (rawValue) => {
+            const normalized = normalize(rawValue);
+            if (normalized === lastSavedNormalized) {
+                setStatus('');
+                if (!normalized && textarea.value && !textarea.value.trim()) {
+                    textarea.value = '';
+                }
+                return;
+            }
+
+            try {
+                setStatus('Saving…');
+                const hasNote = await saveParkNoteToIndexedDB(reference, rawValue);
+                if (hasNote) {
+                    const normalizedValue = normalize(textarea.value);
+                    textarea.value = normalizedValue;
+                    lastSavedNormalized = normalizedValue;
+                } else {
+                    textarea.value = '';
+                    lastSavedNormalized = '';
+                }
+                card.classList.toggle('has-note', hasNote);
+                if (parkRecord) {
+                    if (hasNote) parkRecord.__hasNotes = true;
+                    else delete parkRecord.__hasNotes;
+                }
+                updateMarkerNotesVisual(marker, hasNote);
+                setStatus(hasNote ? 'Saved' : 'Note cleared');
+            } catch (e) {
+                console.warn('saveParkNoteToIndexedDB failed:', e);
+                setStatus('Could not save note', true);
+            }
+        };
+
+        const scheduleSave = (immediate = false) => {
+            if (saveTimer) {
+                clearTimeout(saveTimer);
+                saveTimer = null;
+            }
+            const normalized = normalize(textarea.value);
+            if (normalized === lastSavedNormalized) {
+                setStatus('');
+                if (!normalized && textarea.value && !textarea.value.trim()) {
+                    textarea.value = '';
+                }
+                return;
+            }
+            if (immediate) {
+                persist(textarea.value);
+                return;
+            }
+            setStatus('Saving…');
+            saveTimer = setTimeout(() => {
+                saveTimer = null;
+                persist(textarea.value);
+            }, 420);
+        };
+
+        textarea.addEventListener('input', () => scheduleSave(false));
+        textarea.addEventListener('change', () => scheduleSave(true));
+        textarea.addEventListener('blur', () => scheduleSave(true));
+        textarea.addEventListener('keydown', (event) => event.stopPropagation());
+
+        const flip = (toBack) => {
+            card.classList.toggle('is-flipped', toBack);
+            if (toBack) {
+                setTimeout(() => {
+                    try {
+                        textarea.focus({preventScroll: true});
+                    } catch (_) {
+                        try { textarea.focus(); } catch (_) {}
+                    }
+                }, 180);
+            }
+        };
+
+        frontToggle.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            flip(true);
+        });
+
+        backToggle.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            scheduleSave(true);
+            flip(false);
+        });
+
+        return card;
+    } catch (e) {
+        console.warn('buildPopupWithNotes failed:', e);
+        return fallback;
+    }
+}
+
 async function zoomToParkByReference(reference) {
     const allParks = await getAllParksFromIndexedDB();
     const targetPark = allParks.find(p => p.reference === reference);
@@ -3657,7 +4136,8 @@ function parseStructuredQuery(raw) {
         maxDist: null,
         nferWithRefs: [],
         hasNfer: null,         // ← NEW: boolean or null (no filter)
-        hasReview: null        // ← NEW: boolean or null (no filter)
+        hasReview: null,        // ← NEW: boolean or null (no filter)
+        hasNotes: null
     };
     if (!q) return result;
 
@@ -3738,6 +4218,11 @@ function parseStructuredQuery(raw) {
         } else if (key === 'REVIEW') {
             const v = value.toLowerCase();
             result.hasReview = (v === '1' || v === 'true');
+
+        } else if (key === 'NOTES') {
+            const v = value.toLowerCase();
+            if (v === '1' || v === 'true' || v === 'yes') result.hasNotes = true;
+            else if (v === '0' || v === 'false' || v === 'no') result.hasNotes = false;
 
         } else if (key === 'REF' || key === 'REFERENCE' || key === 'ID') {
             const arr = String(value).split(',').map(s => s.trim().toUpperCase()).filter(Boolean);
@@ -3919,6 +4404,14 @@ function parkMatchesStructuredQuery(park, parsed, ctx) {
         const has = !!park.reviewURL;
         if (parsed.hasReview && !has) return false;
         if (parsed.hasReview === false && has) return false;
+    }
+
+    if (parsed.hasNotes !== null) {
+        const notesSet = ctx && ctx.notesRefs;
+        const ref = normalizeNoteRef(park.reference);
+        const has = notesSet instanceof Set ? notesSet.has(ref) : false;
+        if (parsed.hasNotes && !has) return false;
+        if (parsed.hasNotes === false && has) return false;
     }
 
     // 7) NEW
@@ -4310,6 +4803,8 @@ async function runPQL(raw, ctx = {}) {
         const userActivatedRefs = (activations || []).map(a => a.reference);
         const now = Date.now();
         const nferByRef = buildNferByRef(parks);
+        const notesState = await ensureNotesCacheFromIndexedDB();
+        const notesRefs = notesState?.set || new Set();
 
         const fullCtx = {
             bounds,
@@ -4320,6 +4815,7 @@ async function runPQL(raw, ctx = {}) {
             userLat,
             userLng,
             nferByRef,
+            notesRefs,
             ...ctx
         };
 


### PR DESCRIPTION
## Summary
- add IndexedDB-backed storage and caching for personal park notes
- render flip-card popup UI with a notes textarea, auto-save, and visual note halo
- extend structured query parsing to support NOTES filters and show note halos on markers

## Testing
- no automated tests were run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69149996c7c4832a8cdb6098805414cc)