### PR TITLE
Simplify park popup corner toggles

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -540,7 +540,7 @@
 }
 /* Reserve space so the title never sits under the dog-ear */
 .park-popup-front-body {
-    padding-left: 40px;
+    padding-left: 28px;
 }
 .park-popup-face.park-popup-back {
     transform: rotateY(180deg);
@@ -548,38 +548,39 @@
 
 .park-popup-corner-toggle {
     position: absolute;
-    top: -18px;
-    left: -18px;
-    right: auto;
-    width: 46px;
-    height: 46px;
-    border-radius: 50%;
-    border: 2px solid rgba(15, 23, 42, 0.7);
-    background: rgba(255, 255, 255, 0.98);
+    top: -12px;
+    left: -12px;
+    width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.35);
+    background: rgba(255, 255, 255, 0.96);
     color: #0f172a;
     cursor: pointer;
-    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.22);
+    box-shadow: 0 6px 12px rgba(15, 23, 42, 0.18);
     display: flex;
     align-items: center;
     justify-content: center;
     transition: transform 0.16s ease, box-shadow 0.24s ease, background-color 0.24s ease;
     z-index: 3;
     padding: 0;
-    overflow: visible;
 }
 
 .park-popup-corner-toggle .park-popup-corner-icon {
-    width: 20px;
-    height: 20px;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: contain;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cg fill='none' stroke='%23111827' stroke-linecap='round' stroke-linejoin='round' stroke-width='3'%3E%3Cpath d='M8.5 10.2a9.5 9.5 0 0118.3 3.1v.3a9.5 9.5 0 01-9.5 9.4h-4.6'/%3E%3Cpath d='M14.8 6.5L8.5 10l3.9 6.1'/%3E%3C/g%3E%3C/svg%3E");
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    font-size: 0.85rem;
+    font-weight: 700;
+    line-height: 1;
+    color: inherit;
 }
 
 .park-popup-corner-toggle:hover {
     transform: translateY(-2px);
-    box-shadow: 0 14px 26px rgba(15, 23, 42, 0.32);
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.26);
 }
 
 .park-popup-corner-toggle:hover,
@@ -592,54 +593,33 @@
     outline-offset: 3px;
 }
 
-.park-popup-corner-toggle.back .park-popup-corner-icon {
-    transform: scaleX(-1);
-}
-
 .park-popup-card.has-note .park-popup-corner-toggle.front {
     border-color: rgba(4, 120, 87, 0.7);
-    box-shadow: 0 12px 24px rgba(4, 120, 87, 0.28);
+    box-shadow: 0 8px 18px rgba(4, 120, 87, 0.28);
 }
 
-.park-popup-corner-text {
-    position: absolute;
-    bottom: -18px;
-    left: 50%;
-    transform: translateX(-50%);
-    padding: 2px 8px 3px;
-    border-radius: 999px;
-    border: 1px solid rgba(15, 23, 42, 0.18);
-    background: rgba(255, 255, 255, 0.95);
-    color: #0f172a;
-    font-size: 0.55rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    pointer-events: none;
-    box-shadow: 0 4px 10px rgba(15, 23, 42, 0.18);
+.park-popup-card .park-popup-corner-toggle.back {
+    display: none;
 }
 
-.park-popup-corner-text::selection {
-    background: transparent;
+.park-popup-card.is-flipped .park-popup-corner-toggle.front {
+    display: none;
+}
+
+.park-popup-card.is-flipped .park-popup-corner-toggle.back {
+    display: flex;
 }
 
 /* Compact dog-ear for narrow popups */
 .compact-note .park-popup-corner-toggle {
-    top: -14px;
-    left: -14px;
-    width: 36px;
-    height: 36px;
+    top: -10px;
+    left: -10px;
+    width: 24px;
+    height: 24px;
 }
 
 .compact-note .park-popup-corner-toggle .park-popup-corner-icon {
-    width: 18px;
-    height: 18px;
-}
-
-.compact-note .park-popup-corner-text {
-    font-size: 0.5rem;
-    padding: 2px 6px;
-    bottom: -16px;
+    font-size: 0.75rem;
 }
 
 .park-popup-notes-container {
@@ -712,19 +692,13 @@
 
 @media (max-width: 420px) {
     .park-popup-corner-toggle {
-        top: -12px;
-        left: -12px;
-        right: auto;
-        width: 34px;
-        height: 34px;
+        top: -10px;
+        left: -10px;
+        width: 24px;
+        height: 24px;
     }
     .park-popup-corner-toggle .park-popup-corner-icon {
-        width: 18px;
-        height: 18px;
-    }
-    .park-popup-corner-text {
-        bottom: -14px;
-        font-size: 0.48rem;
+        font-size: 0.75rem;
     }
     .park-popup-notes-textarea {
         min-height: 72px;

--- a/scripts2.js
+++ b/scripts2.js
@@ -3970,7 +3970,7 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
         frontToggle.className = 'park-popup-corner-toggle front';
         frontToggle.setAttribute('aria-label', 'Add personal notes');
         frontToggle.title = 'Add personal notes';
-        front.appendChild(frontToggle);
+        card.appendChild(frontToggle);
 
         const frontBody = document.createElement('div');
         frontBody.className = 'park-popup-front-body';
@@ -3986,20 +3986,15 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
         backToggle.className = 'park-popup-corner-toggle back';
         backToggle.setAttribute('aria-label', 'Show park details');
         backToggle.title = 'Show park details';
-        back.appendChild(backToggle);
+        card.appendChild(backToggle);
 
         const addCornerIcon = (toggle) => {
             if (!toggle) return;
             const icon = document.createElement('span');
             icon.className = 'park-popup-corner-icon';
             icon.setAttribute('aria-hidden', 'true');
+            icon.textContent = '←';
             toggle.appendChild(icon);
-
-            const text = document.createElement('span');
-            text.className = 'park-popup-corner-text';
-            text.textContent = 'turn me';
-            text.setAttribute('aria-hidden', 'true');
-            toggle.appendChild(text);
         };
 
         addCornerIcon(frontToggle);


### PR DESCRIPTION
## Summary
- replace the large "Turn Me" dog-ear buttons with compact left-pointing arrows on both popup faces
- restyle the popup corner toggles and hide the back-facing control until the card is flipped

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d59cdbec832a80da296567daa02b)