### PR TITLE
Linkify park notes and style displayed links

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -632,6 +632,30 @@
     align-items: center;
 }
 
+.park-popup-notes-display {
+    width: 100%;
+    box-sizing: border-box;
+    margin-top: 12px;
+    padding: 12px 14px;
+    border-radius: 10px;
+    background: rgba(248, 250, 252, 0.92);
+    color: #1f2937;
+    font-size: 0.92rem;
+    line-height: 1.45;
+    word-break: break-word;
+    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.15);
+}
+
+.park-popup-notes-display a {
+    color: #2563eb;
+    text-decoration: underline;
+    word-break: break-all;
+}
+
+.park-popup-notes-display a:hover {
+    color: #1e40af;
+}
+
 .park-popup-notes-label {
     font-weight: 600;
     font-size: 0.95rem;

--- a/scripts2.js
+++ b/scripts2.js
@@ -83,6 +83,40 @@ function clearPopupLock() {
 // Utility: always return an array (guards against undefined during CSV flows)
 function asArray(x) { return Array.isArray(x) ? x : []; }
 
+function escapeHtml(str) {
+    if (typeof str !== 'string' || !str) return '';
+    return str.replace(/[&<>"']/g, (char) => {
+        switch (char) {
+            case '&': return '&amp;';
+            case '<': return '&lt;';
+            case '>': return '&gt;';
+            case '"': return '&quot;';
+            case "'": return '&#39;';
+            default: return char;
+        }
+    });
+}
+
+function linkifyText(text) {
+    if (typeof text !== 'string' || !text) return '';
+
+    const urlRegex = /\b((?:https?|app|bear|obsidian|note|file):\/\/[^\s<>"')]+)/gi;
+    let result = '';
+    let lastIndex = 0;
+    let match;
+
+    while ((match = urlRegex.exec(text)) !== null) {
+        const url = match[0];
+        result += escapeHtml(text.slice(lastIndex, match.index));
+        const safeURL = url.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+        result += `<a href="${safeURL}" target="_blank" rel="noopener noreferrer">${escapeHtml(url)}</a>`;
+        lastIndex = match.index + url.length;
+    }
+
+    result += escapeHtml(text.slice(lastIndex));
+    return result.replace(/\n/g, '<br>');
+}
+
 // === Global popup opener helper ===
 
 // === Helpers for Go-To-Park popup behavior ===
@@ -3977,6 +4011,11 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
         frontBody.innerHTML = frontHtml || '';
         front.appendChild(frontBody);
 
+        const noteDisplay = document.createElement('div');
+        noteDisplay.className = 'park-popup-notes-display';
+        noteDisplay.hidden = true;
+        front.appendChild(noteDisplay);
+
         const back = document.createElement('section');
         back.className = 'park-popup-face park-popup-back';
         inner.appendChild(back);
@@ -4045,10 +4084,23 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
         textarea.value = existingText;
 
         const normalize = (value) => (typeof value === 'string' ? value.trim() : '');
+
+        const updateNoteDisplay = (rawValue) => {
+            if (!noteDisplay) return;
+            const normalized = normalize(rawValue);
+            if (normalized) {
+                noteDisplay.innerHTML = linkifyText(normalized);
+                noteDisplay.hidden = false;
+            } else {
+                noteDisplay.innerHTML = '';
+                noteDisplay.hidden = true;
+            }
+        };
         let lastSavedNormalized = normalize(existingText);
         if (lastSavedNormalized) {
             card.classList.add('has-note');
         }
+        updateNoteDisplay(existingText);
         if (marker) updateMarkerNotesVisual(marker, !!lastSavedNormalized);
         if (parkRecord) {
             if (lastSavedNormalized) parkRecord.__hasNotes = true;
@@ -4089,6 +4141,7 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
                     if (hasNote) parkRecord.__hasNotes = true;
                     else delete parkRecord.__hasNotes;
                 }
+                updateNoteDisplay(textarea.value);
                 updateMarkerNotesVisual(marker, hasNote);
                 setStatus(hasNote ? 'Saved' : 'Note cleared');
             } catch (e) {


### PR DESCRIPTION
## Summary
- linkify saved note text when rendering popup content so app:// and https:// URIs become clickable
- add reusable HTML escaping helper used by linkifier
- style the rendered note preview container and links to match the popup UI

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914de8b8598832ab97ae372ffb5cec8)