### PR TITLE
Improve mobile popup UI

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -497,6 +497,27 @@
     overflow-wrap: break-word;
 }
 
+@media (max-width: 540px) {
+    .leaflet-popup-content-wrapper {
+        max-width: min(360px, calc(100vw - 24px));
+        border-radius: 14px;
+    }
+
+    .leaflet-popup-content {
+        padding: 10px 12px 12px;
+    }
+
+    .leaflet-popup-tip-container {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+    }
+
+    .leaflet-popup-tip {
+        margin: 0 auto;
+    }
+}
+
 /* Flip card popup for personal park notes */
 .leaflet-popup-content .park-popup-card {
     position: relative;
@@ -1011,21 +1032,33 @@
     font-weight: 600;
     outline: none;
     user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .leaflet-popup-content details.popup-collapsible > summary::-webkit-details-marker {
     display: none;
 }
 
-.leaflet-popup-content details.popup-collapsible > summary::before {
-    content: "▸";
-    display: inline-block;
-    margin-right: 6px;
-    transform: translateY(-1px);
+.leaflet-popup-content details.popup-collapsible > summary .popup-caret {
+    flex: 0 0 auto;
+    width: 1em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85em;
+    transition: transform 0.2s ease;
+    color: #0f172a;
 }
 
-.leaflet-popup-content details.popup-collapsible[open] > summary::before {
-    content: "▾";
+.leaflet-popup-content details.popup-collapsible[open] > summary .popup-caret {
+    transform: rotate(90deg);
+}
+
+.leaflet-popup-content details.popup-collapsible > summary .popup-summary-label {
+    flex: 1;
+    min-width: 0;
 }
 
 .leaflet-popup-content .popup-collapsible-body {

--- a/scripts2.js
+++ b/scripts2.js
@@ -366,15 +366,28 @@ function ensurePopupCollapsibleCss() {
   font-weight: 600;
   outline: none;
   user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .leaflet-popup-content details.popup-collapsible > summary::-webkit-details-marker { display: none; }
-.leaflet-popup-content details.popup-collapsible > summary::before {
-  content: "▸";
-  display: inline-block;
-  margin-right: 6px;
-  transform: translateY(-1px);
+.leaflet-popup-content details.popup-collapsible > summary .popup-caret {
+  flex: 0 0 auto;
+  width: 1em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85em;
+  transition: transform 0.2s ease;
+  color: #0f172a;
 }
-.leaflet-popup-content details.popup-collapsible[open] > summary::before { content: "▾"; }
+.leaflet-popup-content details.popup-collapsible[open] > summary .popup-caret {
+  transform: rotate(90deg);
+}
+.leaflet-popup-content details.popup-collapsible > summary .popup-summary-label {
+  flex: 1;
+  min-width: 0;
+}
 .leaflet-popup-content .popup-collapsible-body {
   padding: 8px 10px 10px;
   border-top: 1px solid rgba(0,0,0,0.08);
@@ -417,7 +430,17 @@ function foldPopupSections(html) {
             }
 
             const summary = document.createElement('summary');
-            summary.textContent = titleText;
+            const caret = document.createElement('span');
+            caret.className = 'popup-caret';
+            caret.setAttribute('aria-hidden', 'true');
+            caret.textContent = '▸';
+
+            const label = document.createElement('span');
+            label.className = 'popup-summary-label';
+            label.textContent = titleText;
+
+            summary.appendChild(caret);
+            summary.appendChild(label);
             details.appendChild(summary);
 
             // Move following siblings (until next <b>...</b> heading or end) into the details body


### PR DESCRIPTION
## Summary
- add a dedicated caret element to popup collapsible headers so the arrow renders reliably on mobile browsers
- update the mobile popup styles so the collapsible header text no longer bunches up and the caret rotates when expanded
- widen the popup container and center the Leaflet tip on narrow screens to prevent the content from being squashed to one side

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69151c7471e0832a9242eab14d6b7546)