### PR TITLE
Fix popup flip layout on mobile

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -522,6 +522,7 @@
 .leaflet-popup-content .park-popup-card {
     position: relative;
     perspective: 1400px;
+    -webkit-perspective: 1400px;
     min-height: 0;
 }
 
@@ -531,10 +532,14 @@
     display: grid;
     transition: transform 0.48s ease;
     transform-style: preserve-3d;
+    -webkit-transform-style: preserve-3d;
+    transform: rotateY(0deg);
+    -webkit-transform: rotateY(0deg);
 }
 
 .park-popup-card.is-flipped .park-popup-inner {
     transform: rotateY(180deg);
+    -webkit-transform: rotateY(180deg);
 }
 
 .park-popup-face {
@@ -542,6 +547,7 @@
     grid-area: 1 / 1 / 2 / 2;
     background: #fff;
     backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
     min-height: 0;
     padding-top: 10px;
 }
@@ -565,6 +571,32 @@
 }
 .park-popup-face.park-popup-back {
     transform: rotateY(180deg);
+    -webkit-transform: rotateY(180deg);
+}
+
+.park-popup-card.no-3d .park-popup-inner {
+    display: block;
+    transform: none;
+    -webkit-transform: none;
+}
+
+.park-popup-card.no-3d .park-popup-face {
+    transform: none;
+    -webkit-transform: none;
+    backface-visibility: visible;
+    -webkit-backface-visibility: visible;
+}
+
+.park-popup-card.no-3d .park-popup-back {
+    display: none;
+}
+
+.park-popup-card.no-3d.is-flipped .park-popup-front {
+    display: none;
+}
+
+.park-popup-card.no-3d.is-flipped .park-popup-back {
+    display: block;
 }
 
 .park-popup-corner-toggle {

--- a/scripts2.js
+++ b/scripts2.js
@@ -139,6 +139,65 @@ function linkifyText(text) {
     return result;
 }
 
+let __popupFlip3DSupport = null;
+
+function supportsPopupFlip3D() {
+    if (__popupFlip3DSupport !== null) return __popupFlip3DSupport;
+
+    if (typeof window === 'undefined') {
+        __popupFlip3DSupport = false;
+        return __popupFlip3DSupport;
+    }
+
+    const test = (property, value) => {
+        try {
+            if (window.CSS && typeof window.CSS.supports === 'function') {
+                if (window.CSS.supports(property, value)) return true;
+            }
+        } catch (_) {
+        }
+        if (typeof document === 'undefined' || !document.createElement) return false;
+        const style = document.createElement('div').style;
+        if (!style) return false;
+        const camel = property.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+        const prefixed = property.replace(/^(-webkit-|-moz-|-ms-)/, '');
+        const camelPrefixed = prefixed.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+        const candidates = [property, camel, `Webkit${camelPrefixed.charAt(0).toUpperCase()}${camelPrefixed.slice(1)}`];
+        return candidates.some((prop) => {
+            if (!(prop in style)) return false;
+            try {
+                style[prop] = value;
+                return style[prop] === value;
+            } catch (_) {
+                return false;
+            }
+        });
+    };
+
+    const transformStyle = test('transform-style', 'preserve-3d') || test('-webkit-transform-style', 'preserve-3d');
+    const backface = test('backface-visibility', 'hidden') || test('-webkit-backface-visibility', 'hidden');
+    const perspective = test('perspective', '1px') || test('-webkit-perspective', '1px');
+
+    __popupFlip3DSupport = !!(transformStyle && backface && perspective);
+    return __popupFlip3DSupport;
+}
+
+function shouldForce2DPopupFlip() {
+    try {
+        if (!supportsPopupFlip3D()) return true;
+        if (typeof navigator === 'undefined') return false;
+        const ua = String(navigator.userAgent || '');
+        const platform = String(navigator.platform || '');
+        const maxTouchPoints = Number(navigator.maxTouchPoints || 0);
+        const isIOSDevice = /iPad|iPhone|iPod/.test(ua);
+        const isTouchMac = /Mac/.test(platform) && maxTouchPoints > 1;
+        const isSafari = /Safari/.test(ua) && !/(Chrome|CriOS|FxiOS|OPiOS|EdgiOS|Edge)/.test(ua);
+        if ((isIOSDevice || isTouchMac) && isSafari) return true;
+    } catch (_) {
+    }
+    return false;
+}
+
 // === Global popup opener helper ===
 
 // === Helpers for Go-To-Park popup behavior ===
@@ -4035,6 +4094,8 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
         const ref = normalizeNoteRef(reference);
         const card = document.createElement('div');
         card.className = 'park-popup-card';
+        const use3DFlip = !shouldForce2DPopupFlip();
+        if (!use3DFlip) card.classList.add('no-3d');
 
         const inner = document.createElement('div');
         inner.className = 'park-popup-inner';
@@ -4069,6 +4130,11 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
         };
 
         const lockToFrontHeight = () => {
+            if (!use3DFlip) {
+                card.style.height = '';
+                card.style.minHeight = '';
+                return;
+            }
             if (frontHeight) {
                 card.style.height = `${frontHeight}px`;
                 card.style.minHeight = `${frontHeight}px`;
@@ -4076,6 +4142,11 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
         };
 
         const releaseFrontHeight = () => {
+            if (!use3DFlip) {
+                card.style.height = '';
+                card.style.minHeight = '';
+                return;
+            }
             card.style.height = '';
             if (frontHeight) {
                 card.style.minHeight = `${frontHeight}px`;
@@ -4287,6 +4358,16 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
                 measureFrontHeight();
             }
             card.classList.toggle('is-flipped', toBack);
+            const showBack = !!toBack;
+            front.setAttribute('aria-hidden', showBack ? 'true' : 'false');
+            back.setAttribute('aria-hidden', showBack ? 'false' : 'true');
+            if (!use3DFlip) {
+                front.hidden = showBack;
+                back.hidden = !showBack;
+            } else {
+                front.hidden = false;
+                back.hidden = false;
+            }
             if (toBack) {
                 releaseFrontHeight();
                 setTimeout(() => {
@@ -4301,6 +4382,13 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
                 lockToFrontHeight();
             }
         };
+
+        front.setAttribute('aria-hidden', 'false');
+        back.setAttribute('aria-hidden', 'true');
+        if (!use3DFlip) {
+            front.hidden = false;
+            back.hidden = true;
+        }
 
         frontToggle.addEventListener('click', (event) => {
             event.preventDefault();


### PR DESCRIPTION
## Summary
- detect when park popup flip animations are unsupported or unreliable and fall back to a single-face toggle
- update popup-flip logic to manage visibility/aria states so only the active face renders on mobile Safari
- add vendor-prefixed 3D styles and a no-3D fallback layout for park popups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915ee40fa5c832abb32c0977f3844d7)