### PR TITLE
Add toggleable notes editor link

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -709,11 +709,39 @@
     color: #1e40af;
 }
 
+.park-popup-notes-empty {
+    color: #6b7280;
+    font-style: italic;
+}
+
 .park-popup-notes-label {
     font-weight: 600;
     font-size: 0.95rem;
     text-align: center;
     color: #0f172a;
+}
+
+.park-popup-note-actions {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.park-popup-edit-link {
+    background: none;
+    border: none;
+    color: #2563eb;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 0;
+    text-decoration: underline;
+}
+
+.park-popup-edit-link:hover,
+.park-popup-edit-link:focus-visible {
+    color: #1e40af;
+    outline: none;
 }
 
 .park-popup-notes-editor {

--- a/scripts2.js
+++ b/scripts2.js
@@ -4218,8 +4218,25 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
         label.textContent = `Notes for ${reference}`;
         notesContainer.appendChild(label);
 
+        const noteDisplayEl = document.createElement('div');
+        noteDisplayEl.className = 'park-popup-notes-display';
+        noteDisplayEl.hidden = true;
+        notesContainer.appendChild(noteDisplayEl);
+
+        const actions = document.createElement('div');
+        actions.className = 'park-popup-note-actions';
+        notesContainer.appendChild(actions);
+
+        const editButton = document.createElement('button');
+        editButton.type = 'button';
+        editButton.className = 'park-popup-edit-link';
+        editButton.textContent = 'Edit notes';
+        editButton.setAttribute('aria-expanded', 'false');
+        actions.appendChild(editButton);
+
         const editor = document.createElement('div');
         editor.className = 'park-popup-notes-editor';
+        editor.hidden = true;
         notesContainer.appendChild(editor);
 
         const textarea = document.createElement('textarea');
@@ -4233,16 +4250,13 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
         const hint = document.createElement('div');
         hint.className = 'park-popup-note-hint';
         hint.textContent = 'Notes stay on this device and are not shared.';
+        hint.hidden = true;
         notesContainer.appendChild(hint);
-
-        const noteDisplayEl = document.createElement('div');
-        noteDisplayEl.className = 'park-popup-notes-display';
-        noteDisplayEl.hidden = true;
-        notesContainer.appendChild(noteDisplayEl);
 
         const status = document.createElement('div');
         status.className = 'park-popup-note-status';
         status.setAttribute('aria-live', 'polite');
+        status.hidden = true;
         notesContainer.appendChild(status);
 
         const state = await ensureNotesCacheFromIndexedDB();
@@ -4252,16 +4266,36 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
 
         const normalize = (value) => (typeof value === 'string' ? value.trim() : '');
 
+        let isEditing = false;
+
+        const updateEditLabel = (hasNote) => {
+            const label = hasNote ? 'Edit notes' : 'Add notes';
+            editButton.textContent = isEditing ? 'Done' : label;
+            editButton.setAttribute('aria-expanded', isEditing ? 'true' : 'false');
+        };
+
         const updateNoteDisplay = (rawValue) => {
-            if (!noteDisplayEl) return;
             const normalized = normalize(rawValue);
-            if (normalized) {
-                noteDisplayEl.innerHTML = linkifyText(normalized);
-                noteDisplayEl.hidden = false;
-            } else {
-                noteDisplayEl.innerHTML = '';
-                noteDisplayEl.hidden = true;
-            }
+            const targets = [noteDisplayEl, noteDisplay];
+            const hasContent = !!normalized;
+            targets.forEach((el) => {
+                if (!el) return;
+                if (hasContent) {
+                    el.innerHTML = linkifyText(normalized);
+                    el.hidden = false;
+                    el.classList.remove('empty');
+                } else {
+                    el.innerHTML = '';
+                    el.classList.toggle('empty', true);
+                    if (el === noteDisplayEl) {
+                        el.innerHTML = '<span class="park-popup-notes-empty">No personal notes yet.</span>';
+                        el.hidden = false;
+                    } else {
+                        el.hidden = true;
+                    }
+                }
+            });
+            updateEditLabel(hasContent);
         };
         let lastSavedNormalized = normalize(existingText);
         if (lastSavedNormalized) {
@@ -4278,6 +4312,7 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
             if (!status) return;
             status.textContent = msg || '';
             status.classList.toggle('error', !!isError);
+            status.hidden = !isEditing && !msg;
         };
 
         let saveTimer = null;
@@ -4341,21 +4376,51 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
             }, 420);
         };
 
-        textarea.addEventListener('input', () => scheduleSave(false));
-        textarea.addEventListener('change', () => scheduleSave(true));
-        textarea.addEventListener('focus', () => {
-            card.classList.add('notes-editing');
-            releaseFrontHeight();
-        });
-        textarea.addEventListener('blur', () => {
-            card.classList.remove('notes-editing');
-            scheduleSave(true);
-            if (!card.classList.contains('is-flipped')) {
+        const setEditing = (editing, {focusTextarea = true} = {}) => {
+            const nextState = !!editing;
+            isEditing = nextState;
+            card.classList.toggle('notes-editing', nextState);
+            editor.hidden = !nextState;
+            hint.hidden = !nextState;
+            status.hidden = !nextState && !status.textContent;
+            updateEditLabel(!!lastSavedNormalized);
+            if (nextState) {
+                releaseFrontHeight();
+                if (focusTextarea) {
+                    setTimeout(() => {
+                        try { textarea.focus({preventScroll: true}); }
+                        catch (_) { try { textarea.focus(); } catch (_) { } }
+                    }, 40);
+                }
+            } else if (!card.classList.contains('is-flipped')) {
                 measureFrontHeight();
                 lockToFrontHeight();
             }
+        };
+
+        textarea.addEventListener('input', () => scheduleSave(false));
+        textarea.addEventListener('change', () => scheduleSave(true));
+        textarea.addEventListener('focus', () => setEditing(true, {focusTextarea: false}));
+        textarea.addEventListener('blur', () => {
+            scheduleSave(true);
+            setTimeout(() => {
+                try {
+                    const active = document.activeElement;
+                    if (!editor.contains(active)) {
+                        setEditing(false, {focusTextarea: false});
+                    }
+                } catch (_) {
+                }
+            }, 120);
         });
         textarea.addEventListener('keydown', (event) => event.stopPropagation());
+        editButton.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            const next = !isEditing;
+            setEditing(next);
+            if (!next) scheduleSave(true);
+        });
 
         const flip = (toBack) => {
             if (!frontHeight) {
@@ -4376,15 +4441,9 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
             }
             if (toBack) {
                 releaseFrontHeight();
-                setTimeout(() => {
-                    try {
-                        textarea.focus({preventScroll: true});
-                    } catch (_) {
-                        try { textarea.focus(); } catch (_) {}
-                    }
-                }, 180);
+                setEditing(false, {focusTextarea: false});
             } else {
-                card.classList.remove('notes-editing');
+                setEditing(false, {focusTextarea: false});
                 lockToFrontHeight();
             }
         };
@@ -4408,6 +4467,8 @@ async function buildPopupWithNotes({reference, frontHtml, marker, parkRecord}) {
             scheduleSave(true);
             flip(false);
         });
+
+        setEditing(false, {focusTextarea: false});
 
         return card;
     } catch (e) {


### PR DESCRIPTION
## Summary
- add an Edit link in the notes popup that toggles the textarea on demand
- hide note editing controls when not in use while keeping a linkified display of saved notes
- style the new edit control and empty-state hint for the park popup notes panel

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f85564238832ab30e9cb8022a6753)