### PR TITLE
Hide notes editor until activated

### DIFF
--- a/potaMapStyles.css
+++ b/potaMapStyles.css
@@ -709,6 +709,11 @@
     color: #1e40af;
 }
 
+.park-popup-notes-empty {
+    color: #6b7280;
+    font-style: italic;
+}
+
 .park-popup-notes-label {
     font-weight: 600;
     font-size: 0.95rem;
@@ -716,10 +721,37 @@
     color: #0f172a;
 }
 
-.park-popup-notes-editor {
+.park-popup-note-actions {
     width: 100%;
     display: flex;
+    justify-content: flex-end;
+}
+
+.park-popup-edit-link {
+    background: none;
+    border: none;
+    color: #2563eb;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 0;
+    text-decoration: underline;
+}
+
+.park-popup-edit-link:hover,
+.park-popup-edit-link:focus-visible {
+    color: #1e40af;
+    outline: none;
+}
+
+.park-popup-notes-editor {
+    width: 100%;
+    display: none;
     justify-content: center;
+}
+
+.park-popup-card.notes-editing .park-popup-notes-editor {
+    display: flex;
 }
 
 .park-popup-notes-textarea {


### PR DESCRIPTION
## Summary
- hide the park notes editor by default so it only appears when the notes editing state is active
- ensure the editor becomes visible when Add/Edit note is selected and hides again after finishing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f85564238832ab30e9cb8022a6753)